### PR TITLE
Use GraphQL fragments for Link fields

### DIFF
--- a/components/CreateLinkScreen.js
+++ b/components/CreateLinkScreen.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
-import { Platform, StyleSheet, TextInput, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import Button from 'react-native-platform-button';
 import { graphql, gql } from 'react-apollo';
 import { getUser } from 'react-native-authentication-helpers';
 
 import StyledTextInput from './StyledTextInput';
+import Link from './Link';
 import { ALL_LINKS_QUERY } from './LinkListContainer';
 
 class CreateLinkScreen extends Component {
@@ -135,23 +136,10 @@ const CREATE_LINK_MUTATION = gql`
       score: 0
       postedById: $postedById
     ) {
-      id
-      createdAt
-      url
-      description
-      score
-      postedBy {
-        id
-        name
-      }
-      votes {
-        id
-        user {
-          id
-        }
-      }
+      ...LinkFragment
     }
   }
+  ${Link.fragments.link}
 `;
 
 export default graphql(CREATE_LINK_MUTATION, { name: 'createLinkMutation' })(

--- a/components/Link.js
+++ b/components/Link.js
@@ -10,6 +10,26 @@ import { maybeAddProtocol, getHostname } from '../utils/url';
 import timeDifferenceForDate from '../utils/timeDifferenceForDate';
 
 class Link extends PureComponent {
+  static fragments = {
+    link: gql`
+      fragment LinkFragment on Link {
+        id
+        url
+        description
+        createdAt
+        postedBy {
+          name
+        }
+        votes {
+          id
+          user {
+            id
+          }
+        }
+      }
+    `,
+  };
+
   render() {
     const { postedBy } = this.props.link;
     const postedByName = (postedBy && postedBy.name) || 'Unknown';

--- a/components/LinkListContainer.js
+++ b/components/LinkListContainer.js
@@ -1,15 +1,8 @@
 import React, { Component } from 'react';
-import {
-  Platform,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
 import { graphql, gql } from 'react-apollo';
 
 import LinkList from './LinkList';
-import getNavigationParam from '../utils/getNavigationParam';
+import Link from './Link';
 
 const LINKS_PER_PAGE = 10;
 
@@ -50,20 +43,7 @@ class LinkListContainer extends Component {
               id
               link {
                 id
-                url
-                description
-                createdAt
-                score
-                postedBy {
-                  id
-                  name
-                }
-                votes {
-                  id
-                  user {
-                    id
-                  }
-                }
+                ...LinkFragment
               }
               user {
                 id
@@ -71,6 +51,7 @@ class LinkListContainer extends Component {
             }
           }
         }
+        ${Link.fragments.link}
       `,
       updateQuery: (previous, { subscriptionData }) => {
         const votedLinkIndex = previous.allLinks.findIndex(
@@ -111,25 +92,13 @@ export const ALL_LINKS_QUERY = gql`
   query AllLinksQuery($first: Int, $skip: Int, $orderBy: LinkOrderBy) {
     allLinks(first: $first, skip: $skip, orderBy: $orderBy) {
       id
-      createdAt
-      url
-      description
-      score
-      postedBy {
-        id
-        name
-      }
-      votes {
-        id
-        user {
-          id
-        }
-      }
+      ...LinkFragment
     }
     _allLinksMeta {
       count
     }
   }
+  ${Link.fragments.link}
 `;
 
 const orderForListType = listType =>

--- a/components/SearchScreen.js
+++ b/components/SearchScreen.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Platform, StyleSheet, Text, View } from 'react-native';
-import { Constants } from 'expo';
+import { Platform } from 'react-native';
 import SearchLayout from 'react-navigation-addon-search-layout';
 import { gql, withApollo } from 'react-apollo';
 
 import Colors from '../constants/Colors';
 import LinkList from './LinkList';
+import Link from './Link';
 
 class SearchScreen extends React.Component {
   state = {
@@ -76,12 +76,6 @@ class SearchScreen extends React.Component {
   };
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-});
-
 const ALL_LINKS_SEARCH_QUERY = gql`
   query AllLinksSearchQuery($searchText: String!) {
     allLinks(
@@ -93,21 +87,10 @@ const ALL_LINKS_SEARCH_QUERY = gql`
       }
     ) {
       id
-      url
-      description
-      createdAt
-      postedBy {
-        id
-        name
-      }
-      votes {
-        id
-        user {
-          id
-        }
-      }
+      ...LinkFragment
     }
   }
+  ${Link.fragments.link}
 `;
 
 export default withApollo(SearchScreen);


### PR DESCRIPTION
* The fields are colocated in the component that uses them. This makes it easier to spot overfetching/underfetching (already found out that `postedBy.id` and `score` were unused but still fetched).
* There is less duplication in queries. This makes it easier to change the data requirements of a component.